### PR TITLE
Fixes ThreadHelper.JoinableTaskFactory throws when running test on Visual Studio 2017

### DIFF
--- a/src/VsixTesting.Invoker/InvokerPackage.cs
+++ b/src/VsixTesting.Invoker/InvokerPackage.cs
@@ -9,10 +9,8 @@ namespace VsixTesting.Invoker
 
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [ProvideAutomationObject(AutomationObjectName)]
-#if DEBUG
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.NoSolution_string)]
-#endif
     public sealed class InvokerPackage : Package
     {
         private const string AutomationObjectName = "VsixTesting.Invoker";

--- a/src/VsixTesting.Invoker/InvokerPackage.cs
+++ b/src/VsixTesting.Invoker/InvokerPackage.cs
@@ -32,15 +32,20 @@ namespace VsixTesting.Invoker
         {
             if (GetService(typeof(DTE)) is DTE dte)
             {
-                // Initialize the ThreadHelper.JoinableTaskFactory property on UI thread for Microsoft.VisualStudio.Shell.14.0 and above
+                // Initialize the VsTaskLibraryHelper.ServiceInstance property on UI thread for Microsoft.VisualStudio.Shell.14.0 and above
                 var majorVersion = new Version(dte.Version).Major;
                 for (var shellVersion = majorVersion; shellVersion >= 14; shellVersion--)
                 {
-                    var threadHelperTypeName = $"Microsoft.VisualStudio.Shell.ThreadHelper, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-                    var joinableTaskFactoryProperty = Type.GetType(threadHelperTypeName, false)?.GetProperty("JoinableTaskFactory");
-                    joinableTaskFactoryProperty?.GetValue(null);
+                    GetVsTaskLibraryHelperServiceInstance(shellVersion);
                 }
             }
+        }
+
+        private static object GetVsTaskLibraryHelperServiceInstance(int version)
+        {
+            var type = Type.GetType($"Microsoft.VisualStudio.Shell.VsTaskLibraryHelper, Microsoft.VisualStudio.Shell.{version}.0, Version={version}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
+            var prop = type?.GetProperty("ServiceInstance", new Type[0]);
+            return prop?.GetValue(null);
         }
     }
 }

--- a/src/VsixTesting.Invoker/InvokerPackage.cs
+++ b/src/VsixTesting.Invoker/InvokerPackage.cs
@@ -5,12 +5,13 @@ namespace VsixTesting.Invoker
     using System;
     using Microsoft.VisualStudio;
     using Microsoft.VisualStudio.Shell;
-    using EnvDTE;
 
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [ProvideAutomationObject(AutomationObjectName)]
+#if DEBUG
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.NoSolution_string)]
+#endif
     public sealed class InvokerPackage : Package
     {
         private const string AutomationObjectName = "VsixTesting.Invoker";
@@ -23,29 +24,9 @@ namespace VsixTesting.Invoker
             return base.GetAutomationObject(name);
         }
 
+#if DEBUG
         protected override void Initialize()
-        {
-            InitializeThreadHelper();
-        }
-
-        private void InitializeThreadHelper()
-        {
-            if (GetService(typeof(DTE)) is DTE dte)
-            {
-                // Initialize the VsTaskLibraryHelper.ServiceInstance property on UI thread for Microsoft.VisualStudio.Shell.14.0 and above
-                var majorVersion = new Version(dte.Version).Major;
-                for (var shellVersion = majorVersion; shellVersion >= 14; shellVersion--)
-                {
-                    GetVsTaskLibraryHelperServiceInstance(shellVersion);
-                }
-            }
-        }
-
-        private static object GetVsTaskLibraryHelperServiceInstance(int version)
-        {
-            var type = Type.GetType($"Microsoft.VisualStudio.Shell.VsTaskLibraryHelper, Microsoft.VisualStudio.Shell.{version}.0, Version={version}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
-            var prop = type?.GetProperty("ServiceInstance", new Type[0]);
-            return prop?.GetValue(null);
-        }
+            => base.Initialize();
+#endif
     }
 }

--- a/src/VsixTesting/Remote.cs
+++ b/src/VsixTesting/Remote.cs
@@ -57,9 +57,19 @@ namespace VsixTesting
             () =>
             {
                 var dte = ServiceProvider.GlobalProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
+
+                // Initialize ServiceProvider.GlobalProvider in Visual Studio 2010 SDK and above
                 for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 10; shellVersion--)
                 {
                     var type = Type.GetType($"Microsoft.VisualStudio.Shell.ServiceProvider, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
+                    var prop = type?.GetProperty("GlobalProvider", new Type[0]);
+                    prop?.GetValue(null);
+                }
+
+                // Initialize AsyncServiceProvider.GlobalProvider in Visual Studio 2015 SDK and above
+                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 14; shellVersion--)
+                {
+                    var type = Type.GetType($"Microsoft.VisualStudio.Shell.AsyncServiceProvider, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
                     var prop = type?.GetProperty("GlobalProvider", new Type[0]);
                     prop?.GetValue(null);
                 }

--- a/src/VsixTesting/Remote.cs
+++ b/src/VsixTesting/Remote.cs
@@ -8,8 +8,6 @@ namespace VsixTesting
     using System.Reflection;
     using System.Runtime.Remoting;
     using System.Runtime.Remoting.Channels;
-    using System.Windows;
-    using System.Windows.Threading;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
     using VsixTesting.Remoting;
@@ -55,7 +53,7 @@ namespace VsixTesting
 
         public static void InitVsTaskLibraryHelperServiceInstance()
         {
-            Application.Current.Dispatcher.Invoke(
+            ThreadHelper.Generic.Invoke(
             () =>
             {
                 var dte = ServiceProvider.GlobalProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
@@ -65,7 +63,7 @@ namespace VsixTesting
                     var prop = type?.GetProperty("ServiceInstance", new Type[0]);
                     prop?.GetValue(null);
                 }
-            }, DispatcherPriority.Background);
+            });
         }
 
         public static void Dispose()

--- a/src/VsixTesting/Remote.cs
+++ b/src/VsixTesting/Remote.cs
@@ -57,7 +57,7 @@ namespace VsixTesting
             () =>
             {
                 var dte = ServiceProvider.GlobalProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
-                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 11; shellVersion--)
+                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 10; shellVersion--)
                 {
                     var type = Type.GetType($"Microsoft.VisualStudio.Shell.ServiceProvider, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
                     var prop = type?.GetProperty("GlobalProvider", new Type[0]);

--- a/src/VsixTesting/Remote.cs
+++ b/src/VsixTesting/Remote.cs
@@ -51,16 +51,16 @@ namespace VsixTesting
             process.Exited += (_, e) => Process.GetCurrentProcess().Kill();
         }
 
-        public static void InitVsTaskLibraryHelperServiceInstance()
+        public static void InitServiceProviderGlobalProvider()
         {
             ThreadHelper.Generic.Invoke(
             () =>
             {
                 var dte = ServiceProvider.GlobalProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
-                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 14; shellVersion--)
+                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 11; shellVersion--)
                 {
-                    var type = Type.GetType($"Microsoft.VisualStudio.Shell.VsTaskLibraryHelper, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
-                    var prop = type?.GetProperty("ServiceInstance", new Type[0]);
+                    var type = Type.GetType($"Microsoft.VisualStudio.Shell.ServiceProvider, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
+                    var prop = type?.GetProperty("GlobalProvider", new Type[0]);
                     prop?.GetValue(null);
                 }
             });

--- a/src/VsixTesting/Remote.cs
+++ b/src/VsixTesting/Remote.cs
@@ -8,6 +8,7 @@ namespace VsixTesting
     using System.Reflection;
     using System.Runtime.Remoting;
     using System.Runtime.Remoting.Channels;
+    using System.Windows;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
     using VsixTesting.Remoting;
@@ -53,8 +54,7 @@ namespace VsixTesting
 
         public static void InitServiceProviderGlobalProvider()
         {
-            ThreadHelper.Generic.Invoke(
-            () =>
+            Application.Current.Dispatcher.Invoke(() =>
             {
                 var dte = ServiceProvider.GlobalProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
 

--- a/src/VsixTesting/Remote.cs
+++ b/src/VsixTesting/Remote.cs
@@ -9,8 +9,6 @@ namespace VsixTesting
     using System.Runtime.Remoting;
     using System.Runtime.Remoting.Channels;
     using System.Windows;
-    using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Shell.Interop;
     using VsixTesting.Remoting;
 
     internal sealed class Remote
@@ -56,10 +54,10 @@ namespace VsixTesting
         {
             Application.Current.Dispatcher.Invoke(() =>
             {
-                var dte = ServiceProvider.GlobalProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
+                var majorVersion = Process.GetCurrentProcess().MainModule.FileVersionInfo.FileMajorPart;
 
                 // Initialize ServiceProvider.GlobalProvider in Visual Studio 2010 SDK and above
-                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 10; shellVersion--)
+                for (var shellVersion = majorVersion; shellVersion >= 10; shellVersion--)
                 {
                     var type = Type.GetType($"Microsoft.VisualStudio.Shell.ServiceProvider, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
                     var prop = type?.GetProperty("GlobalProvider", new Type[0]);
@@ -67,7 +65,7 @@ namespace VsixTesting
                 }
 
                 // Initialize AsyncServiceProvider.GlobalProvider in Visual Studio 2015 SDK and above
-                for (var shellVersion = new Version(dte.Version).Major; shellVersion >= 14; shellVersion--)
+                for (var shellVersion = majorVersion; shellVersion >= 14; shellVersion--)
                 {
                     var type = Type.GetType($"Microsoft.VisualStudio.Shell.AsyncServiceProvider, Microsoft.VisualStudio.Shell.{shellVersion}.0, Version={shellVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
                     var prop = type?.GetProperty("GlobalProvider", new Type[0]);

--- a/src/VsixTesting/VsInstance.cs
+++ b/src/VsixTesting/VsInstance.cs
@@ -81,6 +81,7 @@ namespace VsixTesting
                     killProcessJob = new KillProcessJob(process);
                     var dte = await VisualStudioUtil.GetDTE(process, timeout);
                     var invoker = (IRemoteComInvoker)dte.GetObject("VsixTesting.Invoker");
+                    InvokeRemote(invoker, nameof(Remote.InitVsTaskLibraryHelperServiceInstance));
                     InvokeRemote(invoker, nameof(Remote.AutoKillWhenProcessExits), Process.GetCurrentProcess().Id);
                     killProcessJob.Release();
                     return new VsInstance(hive.Version, process, dte, invoker);

--- a/src/VsixTesting/VsInstance.cs
+++ b/src/VsixTesting/VsInstance.cs
@@ -81,7 +81,7 @@ namespace VsixTesting
                     killProcessJob = new KillProcessJob(process);
                     var dte = await VisualStudioUtil.GetDTE(process, timeout);
                     var invoker = (IRemoteComInvoker)dte.GetObject("VsixTesting.Invoker");
-                    InvokeRemote(invoker, nameof(Remote.InitVsTaskLibraryHelperServiceInstance));
+                    InvokeRemote(invoker, nameof(Remote.InitServiceProviderGlobalProvider));
                     InvokeRemote(invoker, nameof(Remote.AutoKillWhenProcessExits), Process.GetCurrentProcess().Id);
                     killProcessJob.Release();
                     return new VsInstance(hive.Version, process, dte, invoker);

--- a/test/VsixTesting.Xunit.Tests/VsFactTests.cs
+++ b/test/VsixTesting.Xunit.Tests/VsFactTests.cs
@@ -111,7 +111,7 @@ namespace VsixTesting.XunitX.Tests
                 Assert.IsType<DispatcherSynchronizationContext>(SynchronizationContext.Current);
             }
 
-            [VsFact(Version = "2017")]
+            [VsFact(Version = "2017", ReuseInstance = false)]
             public void CanFindVsTaskLibraryHelperServiceInstance()
             {
                 // Check VsTaskLibraryHelper.ServiceInstance from Microsoft.VisualStudio.Shell.14.0

--- a/test/VsixTesting.Xunit.Tests/VsFactTests.cs
+++ b/test/VsixTesting.Xunit.Tests/VsFactTests.cs
@@ -112,12 +112,19 @@ namespace VsixTesting.XunitX.Tests
             }
 
             [VsFact(Version = "2017")]
-            public void CanFindMPF14JoinableTaskFactory()
+            public void CanFindVsTaskLibraryHelperServiceInstance()
             {
-                // Check we can retrieve ThreadHelper.JoinableTaskFactory from Microsoft.VisualStudio.Shell.14.0 when running in Visual Studio 2017
-                var type = Type.GetType("Microsoft.VisualStudio.Shell.ThreadHelper, Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", true);
-                var joinableTaskFactory = type.GetProperty("JoinableTaskFactory").GetValue(null);
-                Assert.NotNull(joinableTaskFactory);
+                // Check VsTaskLibraryHelper.ServiceInstance from Microsoft.VisualStudio.Shell.14.0
+                // has been initialized when running in Visual Studio 2017
+                var serviceInstance = GetVsTaskLibraryHelperServiceInstance(14);
+                Assert.NotNull(serviceInstance);
+            }
+
+            private static object GetVsTaskLibraryHelperServiceInstance(int version)
+            {
+                var type = Type.GetType($"Microsoft.VisualStudio.Shell.VsTaskLibraryHelper, Microsoft.VisualStudio.Shell.{version}.0, Version={version}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false);
+                var prop = type?.GetProperty("ServiceInstance", new Type[0]);
+                return prop?.GetValue(null);
             }
         }
 

--- a/test/VsixTesting.Xunit.Tests/VsFactTests.cs
+++ b/test/VsixTesting.Xunit.Tests/VsFactTests.cs
@@ -110,6 +110,15 @@ namespace VsixTesting.XunitX.Tests
                 await Task.Yield();
                 Assert.IsType<DispatcherSynchronizationContext>(SynchronizationContext.Current);
             }
+
+            [VsFact(Version = "2017")]
+            public void CanFindMPF14JoinableTaskFactory()
+            {
+                // Check we can retrieve ThreadHelper.JoinableTaskFactory from Microsoft.VisualStudio.Shell.14.0 when running in Visual Studio 2017
+                var type = Type.GetType("Microsoft.VisualStudio.Shell.ThreadHelper, Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", true);
+                var joinableTaskFactory = type.GetProperty("JoinableTaskFactory").GetValue(null);
+                Assert.NotNull(joinableTaskFactory);
+            }
         }
 
         public class BackgroundThreadTests

--- a/test/VsixTesting.Xunit.Tests/VsixTesting.Xunit.Tests.csproj
+++ b/test/VsixTesting.Xunit.Tests/VsixTesting.Xunit.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="VSSDK.ComponentModelHost.11" Version="11.0.4" />
     <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" />
   </ItemGroup>
   <Import Condition="'$(AppVeyor)' == ''" Project="..\..\src\VsixTesting.Xunit\VsixTesting.Xunit.props" />
@@ -21,5 +22,9 @@
   <ItemGroup Condition="'$(AppVeyor)' == ''">
     <ProjectReference Include="..\..\src\VsixTesting\VsixTesting.csproj" />
     <ProjectReference Include="..\..\src\VsixTesting.Xunit\VsixTesting.Xunit.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR should allows tests like the following to pass when running on Visual Studio 2017, when the version of `ThreadHelper` is from `Microsoft.VisualStudio.Shell.14.0`:
```cs
        [VsFact]
        public async Task SwitchToMainThreadAsync()
        {
            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
            Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
        }
```

The reason it might not work at the moment is that it relies on a package to have already called the `ThreadHelper.JoinableTaskFactory` property from the UI thread.

### What this PR does

- Read the `ServiceProvider.GlobalProvider` property from the UI thread for `Microsoft.VisualStudio.Shell.10.0` and above
- Read the `AsyncServiceProvider.GlobalProvider` property from the UI thread for `Microsoft.VisualStudio.Shell.15.0` and above
- Add `CanFindVsTaskLibraryHelperServiceInstance` to check that `VsTaskLibraryHelper.ServiceInstance` doesn't return null when running inside Visual Studio 2017
- Add `CanUseAsyncServiceProviderGetServiceAsync` to check that `await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(SComponentModel))` doesn't return null when running inside Visual Studio 2017

This initializes the `ServiceProvider.GlobalProvider` on the UI thread and ensures that `ThreadHelper.JoinableTaskContext` and `ThreadHelper.JoinableTaskFactory` don't throw.

### How to test

The `CanFindVsTaskLibraryHelperServiceInstance` test should fail without this change.

Fixes #5
