### PR TITLE
Add ability to copy VSIX to output directory

### DIFF
--- a/src/VsixTesting.Xunit/VsixTesting.Xunit.csproj
+++ b/src/VsixTesting.Xunit/VsixTesting.Xunit.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <Content Include="VsixTesting.Xunit.props" PackagePath="build" />
+    <Content Include="VsixTesting.Xunit.targets" PackagePath="build" />
   </ItemGroup>
 
   <PropertyGroup >

--- a/src/VsixTesting.Xunit/VsixTesting.Xunit.targets
+++ b/src/VsixTesting.Xunit/VsixTesting.Xunit.targets
@@ -1,0 +1,75 @@
+﻿<Project>
+  <Target Name="CopyProjectReferenceVsixOutputs"
+          AfterTargets="ResolveProjectReferences"
+          DependsOnTargets="ResolveProjectReferences">
+
+    <FilterVsixProjectReferences Projects="@(_MSBuildProjectReferenceExistent)">
+      <Output TaskParameter="VsixProjects" ItemName="_MSBuildVsixProjectReferenceExistent" />
+    </FilterVsixProjectReferences>
+
+    <MSBuild Projects="@(_MSBuildVsixProjectReferenceExistent)"
+             Targets="VSIXContainerProjectOutputGroup"
+             BuildInParallel="$(BuildInParallel)"
+             Properties="%(_MSBuildVsixProjectReferenceExistent.SetConfiguration); %(_MSBuildVsixProjectReferenceExistent.SetPlatform); %(_MSBuildVsixProjectReferenceExistent.SetTargetFramework);"
+             Condition="'%(_MSBuildVsixProjectReferenceExistent.CopyVsix)' != 'false'"
+             ContinueOnError="$(ContinueOnError)"
+             RemoveProperties="%(_MSBuildVsixProjectReferenceExistent.GlobalPropertiesToRemove)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceVsixOutputs" />
+    </MSBuild>
+    
+    <ItemGroup>
+      <_ProjectReferenceVsixOutputs>
+        <ExtensionsDirectory Condition="$([System.IO.Path]::IsPathRooted('%(_ProjectReferenceVsixOutputs.ExtensionsDirectory)')) == false">$(OutDir)%(_ProjectReferenceVsixOutputs.ExtensionsDirectory)</ExtensionsDirectory>
+      </_ProjectReferenceVsixOutputs>
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="%(_ProjectReferenceVsixOutputs.Identity)"
+      DestinationFolder="%(_ProjectReferenceVsixOutputs.ExtensionsDirectory)"
+      SkipUnchangedFiles="true"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      Condition="Exists(%(_ProjectReferenceVsixOutputs.Identity))">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+    </Copy>
+  </Target>
+
+  <UsingTask TaskName="FilterVsixProjectReferences" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <Projects ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <VsixProjects ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="Microsoft.Build" />
+      <Reference Include="Microsoft.Build.Framework" />
+      <Reference Include="System.Xml" />
+      <Using Namespace="Microsoft.Build.Evaluation" />
+      <Using Namespace="System.IO" />
+
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+            var VSSDKTargets = new[] { "CreateVsixContainer", "VSIXContainerProjectOutputGroup" };
+
+            VsixProjects = Projects.Where(projectReference =>
+            {
+                try
+                {
+                    var projectCollection = new ProjectCollection();
+                    var project = projectCollection.LoadProject(projectReference.ItemSpec);
+                    var isVsixProject = VSSDKTargets.All(targetName => project.Targets.Any(target => target.Key == targetName));
+                    projectCollection.UnloadProject(project);
+                    return isVsixProject;
+                }
+                catch
+                {
+                    return false;
+                }
+            }).ToArray();
+            
+            return true;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>

--- a/test/VsixTesting.Xunit.Tests/ProjectReferenceTests.cs
+++ b/test/VsixTesting.Xunit.Tests/ProjectReferenceTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2018 Jose Torres. All rights reserved. Licensed under the Apache License, Version 2.0. See LICENSE.md file in the project root for full license information.
+
+namespace VsixTesting.XunitX.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using Xunit;
+
+    public class ProjectReferenceTests
+    {
+        const bool CopyVsixDefaultValue = true;
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(true, "CopyVsix", "True.Relative")]
+        [InlineData(true, "CopyVsix", "True.Absolute")]
+        [InlineData(false, "CopyVsix", "False")]
+        void CopyVsix(bool? copyVsix, params string[] paths)
+        {
+            var path = Path.Combine(paths.Concat(new[] { "VsixTesting.Invoker.vsix" }).ToArray());
+            Assert.Equal(copyVsix.GetValueOrDefault(CopyVsixDefaultValue), File.Exists(path));
+        }
+    }
+}

--- a/test/VsixTesting.Xunit.Tests/VsixTesting.Xunit.Tests.csproj
+++ b/test/VsixTesting.Xunit.Tests/VsixTesting.Xunit.Tests.csproj
@@ -27,4 +27,13 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\VsixTesting.Invoker\VsixTesting.Invoker.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\\..\src\VsixTesting.Invoker\VsixTesting.Invoker.csproj" ReferenceOutputAssembly="false" CopyVsix="true" ExtensionsDirectory="CopyVsix/True.Relative" />
+    <ProjectReference Include="..\\\..\src\VsixTesting.Invoker\VsixTesting.Invoker.csproj" ReferenceOutputAssembly="false" CopyVsix="true" ExtensionsDirectory="$(TargetDir)CopyVsix/True.Absolute" />
+    <ProjectReference Include="..\\\\..\src\VsixTesting.Invoker\VsixTesting.Invoker.csproj" ReferenceOutputAssembly="false" CopyVsix="false" ExtensionsDirectory="CopyVsix/False" />
+  </ItemGroup>
+
+  <Import Condition="'$(AppVeyor)' == ''" Project="..\..\src\VsixTesting.Xunit\VsixTesting.Xunit.targets" />
 </Project>


### PR DESCRIPTION
Fixes #9 

This is based on @sharwell's  work with some changes:

* `CreateVsixContainer` target is not called because doing so breaks the build & creates the zip container twice.
* `CopyProjectReferenceVsixOutputs` target runs _after_ `ResolveProjectReferences` because we are not calling the `CreateVsixContainer` target ourselves anymore so we rely on it being called implicitly from the `build` target.
* Added `FilterVsixProjectReferences` task to support earlier versions since `MSBuild`'s parameter `SkipNonExistentTargets` is only available in MSBuild *15.6*.
* Using `Copy` task to support absolute paths.
* Added `ExtensionsDirectory` to be consistent with the setting we already provide in https://github.com/josetr/VsixTesting/blob/234516a103b7ec0ffa811c7ca6fdcdc04b78e660/src/VsixTesting/ITestSettings.cs#L46

The referenced projects must not change `CreateVsixContainer` to `false` since we do not force it to `true` anymore but since the default is `true` this shouldn't be a problem for 99% of the users.

Altho https://github.com/tunnelvisionlabs/MouseFastScroll/pull/27 suffers from the issues I've mentioned, they are "hidden" because
 * MSBuild verbosity is set to minimum
 * MSBuild is building the whole solution. If only the test project is built, it will break.
