### PR TITLE
Improve installer

### DIFF
--- a/src/VsixTesting.ExtensionInstaller/Properties/launchSettings.json
+++ b/src/VsixTesting.ExtensionInstaller/Properties/launchSettings.json
@@ -1,8 +1,28 @@
 {
   "profiles": {
-    "VsixTesting.ExtensionInstaller": {
+    "VsixTesting.ExtensionInstaller.Install": {
       "commandName": "Project",
-      "commandLineArgs": "--RootSuffix Exp --ApplicationPath \"$(DevEnvDir)devenv.exe\" --ExtensionPaths \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
+      "commandLineArgs": "/ApplicationPath \"$(DevEnvDir)devenv.exe\" /RootSuffix Exp /Install \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
+    },
+    "VsixTesting.ExtensionInstaller.Uninstall": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"$(DevEnvDir)devenv.exe\" /RootSuffix Exp /Uninstall 9eef3d53-333f-4be2-900e-a1f104fc325a"
+    },
+    "VsixTesting.ExtensionInstaller.IsProfileInitialized": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"$(DevEnvDir)devenv.exe\" /RootSuffix Exp /IsProfileInitialized"
+    },
+    "VsixTesting.ExtensionInstaller.2012.Install": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio 11.0\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /Install \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
+    },
+    "VsixTesting.ExtensionInstaller.2012.Uninstall": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio 11.0\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /Uninstall 9eef3d53-333f-4be2-900e-a1f104fc325a"
+    },
+    "VsixTesting.ExtensionInstaller.2012.IsProfileInitialized": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio 11.0\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /IsProfileInitialized"
     }
   }
 }

--- a/src/VsixTesting/VsInstance.cs
+++ b/src/VsixTesting/VsInstance.cs
@@ -39,16 +39,15 @@ namespace VsixTesting
         {
             await diagnostics.RunAsync("Preparing Instance", async output =>
             {
-                var installResult = default((int InstallCount, bool HasSettingsFile, string Output));
                 var invokerAssembly = Assembly.GetExecutingAssembly();
+                var isProfileInitialized = false;
 
                 using (var invoker = new TempFile(EmbeddedResourceUtil.ExtractResource(invokerAssembly, "VsixTesting.Invoker.vsix")))
                 {
                     EmbeddedResourceUtil.ApplyDateTime(invoker.Path, invokerAssembly, "VsixTesting.Invoker.vsix");
 
-                    installResult = await VisualStudioUtil.InstallExtensionsAsync(
-                        hive,
-                        extensionsToInstall.Concat(new[] { invoker.Path }));
+                    isProfileInitialized = await VisualStudioUtil.IsProfileInitializedAsync(hive);
+                    var installResult = await VisualStudioUtil.InstallExtensionsAsync(hive, extensionsToInstall.Concat(new[] { invoker.Path }));
 
                     output.WriteLine(installResult.Output);
 
@@ -61,7 +60,7 @@ namespace VsixTesting
                     }
                 }
 
-                if (!installResult.HasSettingsFile || resetSettings)
+                if (!isProfileInitialized || resetSettings)
                 {
                     output.WriteLine("Resetting settings");
                     await VisualStudioUtil.ResetSettingsAsync(hive);


### PR DESCRIPTION
* Install extension as `experimental` if there is already a global extension installed with the same id to avoid asking for elevated privileges
* Run program in a new `AppDomain` to avoid restarting the application since it's not possible to change the main AppDomain configuration at runtime
* Create wrappers for dynamic objects
* Ensure extensions can be loaded from %LOCALAPPDATA%\Microsoft\VisualStudio
* Remove extension from the "PendingDeletions" collection in the registry after install/uninstall
* Ensure `InstallableExtension` version is higher than a globally installed extension with the same id otherwise install would succeed but the global extension would always take precedence.
  * To find if there is a global extension installed, uninstaller now runs in a loop otherwise after uninstalling **local extension 1.1**, **local extension 1.2** may take precedence but there may be a **global extension 1.0** which is installed but ignored since it's version is lower than **local extension 1.2**
* Improve `launchSettings.json` and add profiles for Visual Studio 2012 
* Only restart application using a different filename "ServiceHub.VSDetouredHost.exe" when absolutely needed