### PR TITLE
Fix Installertool for VS 2019 16.0 Preview

### DIFF
--- a/src/VsixTesting.ExtensionInstaller/Program.cs
+++ b/src/VsixTesting.ExtensionInstaller/Program.cs
@@ -13,9 +13,13 @@ namespace VsixTesting.ExtensionInstaller
     using System.Linq;
     using System.Reflection;
     using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.ComTypes;
     using System.Text;
+    using System.Text.RegularExpressions;
+    using EnvDTE80;
     using Microsoft.VisualStudio.ExtensionManager;
     using static VsixTesting.ExtensionInstaller.RestartManager;
+    using DTE = EnvDTE.DTE;
     using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
     internal class Program : MarshalByRefObject
@@ -43,6 +47,18 @@ namespace VsixTesting.ExtensionInstaller
                         {
                             var extensionPaths = CommandLineParser.Many(args, "Install");
                             return Installer.Install(applicationPath, rootSuffix, extensionPaths, allUsers: false);
+                        }
+                    },
+                    {
+                        "InstallAndStart", () =>
+                        {
+                            var extensionPaths = CommandLineParser.Many(args, "InstallAndStart");
+                            var result = Installer.Install(applicationPath, rootSuffix, extensionPaths, allUsers: false);
+                            var dte = VisualStudioUtil.GetDteFromDebuggedProcess(Process.GetCurrentProcess());
+                            var process = Process.Start(applicationPath, $"/RootSuffix {rootSuffix}");
+                            if (dte != null)
+                               VisualStudioUtil.AttachDebugger(dte, process);
+                            return result;
                         }
                     },
                     {
@@ -648,5 +664,117 @@ namespace VsixTesting.ExtensionInstaller
     {
         public static T CreateInstanceFromAndUnwrap<T>(this AppDomain domain)
             => (T)domain.CreateInstanceFromAndUnwrap(typeof(T).Assembly.Location, typeof(T).FullName);
+    }
+
+    internal class VisualStudioUtil
+    {
+        public const string ProcessName = "devenv";
+
+        public static DTE GetDTE(Process process)
+        {
+            string namePattern = $@"!VisualStudio\.DTE\.(\d+\.\d+):{process.Id.ToString()}";
+            return (DTE)RunningObjectTable.GetRunningObjects(namePattern).FirstOrDefault();
+        }
+
+        public static IEnumerable<DTE> GetRunningDTEs()
+        {
+            foreach (var process in Process.GetProcessesByName(ProcessName))
+            {
+                if (GetDTE(process) is DTE dte)
+                    yield return dte;
+            }
+        }
+
+        public static DTE GetDteFromDebuggedProcess(Process process)
+        {
+            foreach (var dte in GetRunningDTEs())
+            {
+                try
+                {
+                    if (dte.Debugger.CurrentMode != EnvDTE.dbgDebugMode.dbgDesignMode)
+                    {
+                        foreach (Process2 debuggedProcess in dte.Debugger.DebuggedProcesses)
+                        {
+                            if (debuggedProcess.ProcessID == process.Id)
+                                return dte;
+                        }
+                    }
+                }
+                catch (COMException)
+                {
+                    continue;
+                }
+            }
+
+            return null;
+        }
+
+        public static void AttachDebugger(DTE dte, Process targetProcess, string engine = "Managed")
+        {
+            dte?.Debugger
+                .LocalProcesses
+                .Cast<Process2>()
+                .FirstOrDefault(p => p.ProcessID == targetProcess.Id)
+                ?.Attach2(engine);
+        }
+    }
+
+    internal static class RunningObjectTable
+    {
+        private const int S_OK = 0;
+
+        public static IEnumerable<object> GetRunningObjects(string namePattern = ".*")
+        {
+            IEnumMoniker enumMoniker = null;
+            IRunningObjectTable rot = null;
+            IBindCtx bindCtx = null;
+
+            try
+            {
+                Marshal.ThrowExceptionForHR(Ole32.CreateBindCtx(0, out bindCtx));
+                bindCtx.GetRunningObjectTable(out rot);
+                rot.EnumRunning(out enumMoniker);
+
+                var moniker = new IMoniker[1];
+                var fetched = IntPtr.Zero;
+
+                while (enumMoniker.Next(1, moniker, fetched) == S_OK)
+                {
+                    object runningObject = null;
+                    try
+                    {
+                        var roMoniker = moniker.First();
+                        if (roMoniker == null)
+                            continue;
+                        roMoniker.GetDisplayName(bindCtx, null, out var name);
+                        if (!Regex.IsMatch(name, namePattern))
+                            continue;
+                        Marshal.ThrowExceptionForHR(rot.GetObject(roMoniker, out runningObject));
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        continue;
+                    }
+
+                    if (runningObject != null)
+                        yield return runningObject;
+                }
+            }
+            finally
+            {
+                if (enumMoniker != null)
+                    Marshal.ReleaseComObject(enumMoniker);
+                if (rot != null)
+                    Marshal.ReleaseComObject(rot);
+                if (bindCtx != null)
+                    Marshal.ReleaseComObject(bindCtx);
+            }
+        }
+    }
+
+    internal static class Ole32
+    {
+        [DllImport("ole32.dll")]
+        public static extern int CreateBindCtx(uint reserved, out IBindCtx ppbc);
     }
 }

--- a/src/VsixTesting.ExtensionInstaller/Program.cs
+++ b/src/VsixTesting.ExtensionInstaller/Program.cs
@@ -376,7 +376,7 @@ namespace VsixTesting.ExtensionInstaller
         {
             var majorVersion = typeof(IVsExtensionManager).Assembly.GetName().Version.Major;
 
-            var assembly = Assembly.Load($"Microsoft.VisualStudio.Settings{(majorVersion == 10 ? string.Empty : $".{majorVersion}.0")}, " +
+            var assembly = Assembly.Load($"Microsoft.VisualStudio.Settings.15.0, " +
                 $"Version={majorVersion}.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
 
             return assembly.GetType("Microsoft.VisualStudio.Settings.ExternalSettingsManager");
@@ -415,7 +415,7 @@ namespace VsixTesting.ExtensionInstaller
         {
             var productVersion = Version.Parse(FileVersionInfo.GetVersionInfo(applicationPath).ProductVersion);
 
-            if (productVersion.Major == 15 && productVersion.Minor == 8)
+            if ((productVersion.Major == 15 && productVersion.Minor == 8) || (productVersion.Major == 16 && productVersion.Minor == 0))
             {
                 try
                 {

--- a/src/VsixTesting.ExtensionInstaller/Properties/launchSettings.json
+++ b/src/VsixTesting.ExtensionInstaller/Properties/launchSettings.json
@@ -4,6 +4,10 @@
       "commandName": "Project",
       "commandLineArgs": "/ApplicationPath \"$(DevEnvDir)devenv.exe\" /RootSuffix Exp /Install \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
     },
+    "VsixTesting.ExtensionInstaller.InstallAndStart": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"$(DevEnvDir)devenv.exe\" /RootSuffix Exp /InstallAndStart \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
+    },
     "VsixTesting.ExtensionInstaller.Uninstall": {
       "commandName": "Project",
       "commandLineArgs": "/ApplicationPath \"$(DevEnvDir)devenv.exe\" /RootSuffix Exp /Uninstall 9eef3d53-333f-4be2-900e-a1f104fc325a"
@@ -15,6 +19,10 @@
     "VsixTesting.ExtensionInstaller.2012.Install": {
       "commandName": "Project",
       "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio 11.0\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /Install \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
+    },
+    "VsixTesting.ExtensionInstaller.2012.InstallAndStart": {
+      "commandName": "Project",
+      "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio 11.0\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /InstallAndStart \"$(SolutionDir)bin\\VsixTesting.Invoker\\$(Configuration)\\net452\\VsixTesting.Invoker.vsix\""
     },
     "VsixTesting.ExtensionInstaller.2012.Uninstall": {
       "commandName": "Project",

--- a/src/VsixTesting.ExtensionInstaller/VsixTesting.ExtensionInstaller.csproj
+++ b/src/VsixTesting.ExtensionInstaller/VsixTesting.ExtensionInstaller.csproj
@@ -2,11 +2,23 @@
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
     <OutputType>Exe</OutputType>
-    <IsPackable>False</IsPackable>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Prefer32Bit>true</Prefer32Bit>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <PackageId>VsixTesting.Installer</PackageId>
+    <IsTool>true</IsTool>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="VsixTesting.Installer.props" PackagePath="build" />
+  </ItemGroup>
+
+  <Target Name="CopyAssembliesToPackage" AfterTargets="Build">
+    <ItemGroup>
+      <Content Include="$(TargetDir)EnvDTE.dll" PackagePath="tools" />
+    </ItemGroup>
+  </Target>
+  
   <ItemGroup>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Configuration" />
@@ -16,5 +28,9 @@
       <SpecificVersion>false</SpecificVersion>
       <Private>False</Private>
     </Reference>
+    <PackageReference Include="EnvDTE" Version="8.0.0" />
+    <PackageReference Include="EnvDTE80" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.17" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.65" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/VsixTesting.ExtensionInstaller/VsixTesting.Installer.props
+++ b/src/VsixTesting.ExtensionInstaller/VsixTesting.Installer.props
@@ -1,0 +1,5 @@
+﻿<Project>
+  <PropertyGroup>
+    <VsixTestingInstallerPath>$(MSBuildThisFileDirectory)../tools/VsixTesting.ExtensionInstaller.exe</VsixTestingInstallerPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Forked from https://github.com/josetr/VsixTesting/tree/InstallerTool.

It looks like the `VSDetouredHost` issue from 15.8 made its way into 16.0. 😢 

This does indeed seem to fix it!