### PR TITLE
Fix: non-async tests hang sometimes when UIThread = true

### DIFF
--- a/src/VsixTesting/Common/MethodInfoExtensions.cs
+++ b/src/VsixTesting/Common/MethodInfoExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) 2018 Jose Torres. All rights reserved. Licensed under the Apache License, Version 2.0. See LICENSE.md file in the project root for full license information.
+
+namespace Common
+{
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+
+    internal static class MethodInfoExtensions
+    {
+        public static bool IsAsync(this MethodInfo methodInfo)
+        {
+            return methodInfo.GetCustomAttribute(typeof(AsyncStateMachineAttribute)) != null;
+        }
+    }
+}

--- a/test/VsixTesting.Xunit.Tests/VsFactTests.cs
+++ b/test/VsixTesting.Xunit.Tests/VsFactTests.cs
@@ -6,6 +6,8 @@ namespace VsixTesting.XunitX.Tests
     using System.Diagnostics;
     using System.IO;
     using System.Threading;
+    using System.Threading.Tasks;
+    using System.Windows;
     using System.Windows.Threading;
     using Microsoft.VisualStudio.ComponentModelHost;
     using Microsoft.VisualStudio.Shell;
@@ -90,8 +92,9 @@ namespace VsixTesting.XunitX.Tests
                 => Assert.Equal(constructorThreadId, Thread.CurrentThread.ManagedThreadId);
 
             [VsFact]
-            void MethodHasSameSyncContextTypeAsConstructor()
+            async void MethodHasSameSyncContextTypeAsConstructor()
             {
+                await Task.Delay(0);
                 var asyncTestSyncContext = (AsyncTestSyncContext)SynchronizationContext.Current;
                 Assert.IsType(synchronizationContext.GetType(), asyncTestSyncContext.GetInnerSyncContext());
             }
@@ -120,6 +123,14 @@ namespace VsixTesting.XunitX.Tests
                 Assert.IsType<DispatcherSynchronizationContext>(asyncTestSyncContext.GetInnerSyncContext());
                 await Task.Yield();
                 Assert.IsType<DispatcherSynchronizationContext>(SynchronizationContext.Current);
+            }
+
+            [VsFact]
+            void DteWindow()
+            {
+                var dte = (EnvDTE.DTE)ServiceProvider.GlobalProvider.GetService(typeof(SDTE));
+                var window = dte.ItemOperations.NewFile(Name: Guid.NewGuid() + ".txt");
+                window.Close(EnvDTE.vsSaveChanges.vsSaveChangesNo);
             }
         }
 

--- a/test/VsixTesting.Xunit.Tests/VsTheoryTests.cs
+++ b/test/VsixTesting.Xunit.Tests/VsTheoryTests.cs
@@ -94,8 +94,9 @@ namespace VsixTesting.XunitX.Tests
 
             [VsTheory]
             [InlineData(0)]
-            void MethodHasSameSyncContextTypeAsConstructor(int zero)
+            async void MethodHasSameSyncContextTypeAsConstructor(int zero)
             {
+                await Task.Delay(0);
                 var asyncTestSyncContext = (AsyncTestSyncContext)SynchronizationContext.Current;
                 Assert.IsType(synchronizationContext.GetType(), asyncTestSyncContext.GetInnerSyncContext());
             }


### PR DESCRIPTION
`Xunit.Sdk.AsyncTestSyncContext` seems to be the problem and it's only purpose is to support `async void` test methods.

So the problem is solved if we dodge it when the test method is not `async ` and `UIThread = true.`